### PR TITLE
Fix possibly not getting max permission node if multiple present, clean up checkMaxShulker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.decryptedx</groupId>
     <artifactId>DCXShulkerLimiter</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/src/main/java/me/decryptedx/dcxshulkerlimiter/DCXPermissionLimitExtractor.java
+++ b/src/main/java/me/decryptedx/dcxshulkerlimiter/DCXPermissionLimitExtractor.java
@@ -1,7 +1,10 @@
 package me.decryptedx.dcxshulkerlimiter;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionAttachmentInfo;
+
+import java.util.logging.Level;
 
 /**
  * Helper class that encapsulates getting a player's highest effective permission for a permission node
@@ -23,11 +26,18 @@ public class DCXPermissionLimitExtractor {
     public int getLimit(String prefix, int defaultValue) {
         if (player == null) return defaultValue;
 
-        return player.getEffectivePermissions().stream()
-                     .map(PermissionAttachmentInfo::getPermission)
-                     .filter(permission -> permission.startsWith(prefix))
-                     .mapToInt(InventoryListener::integerValueFromPermission)
-                     .max()
-                     .orElse(defaultValue);
+        try {
+            return player.getEffectivePermissions().stream()
+                         .map(PermissionAttachmentInfo::getPermission)
+                         .filter(permission -> permission.startsWith(prefix))
+                         .mapToInt(InventoryListener::integerValueFromPermission)
+                         .max()
+                         .orElse(defaultValue);
+        } catch (NumberFormatException | IndexOutOfBoundsException e) {
+            Bukkit.getLogger().log(Level.SEVERE,
+                    "Permission node " + prefix + " for " + player.getName() +
+                    " has a non-integer value, returning default.");
+            return defaultValue;
+        }
     }
 }

--- a/src/main/java/me/decryptedx/dcxshulkerlimiter/DCXPermissionLimitExtractor.java
+++ b/src/main/java/me/decryptedx/dcxshulkerlimiter/DCXPermissionLimitExtractor.java
@@ -1,0 +1,33 @@
+package me.decryptedx.dcxshulkerlimiter;
+
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+
+/**
+ * Helper class that encapsulates getting a player's highest effective permission for a permission node
+ * that starts with a prefix
+ */
+public class DCXPermissionLimitExtractor {
+    private final Player player;
+
+    public DCXPermissionLimitExtractor(final Player player) {
+        this.player = player;
+    }
+
+    /**
+     *
+     * @param prefix Permission node prefix
+     * @param defaultValue Default value of permission
+     * @return Highest value of permission nodes in the player's permission with a given prefix
+     */
+    public int getLimit(String prefix, int defaultValue) {
+        if (player == null) return defaultValue;
+
+        return player.getEffectivePermissions().stream()
+                     .map(PermissionAttachmentInfo::getPermission)
+                     .filter(permission -> permission.startsWith(prefix))
+                     .mapToInt(InventoryListener::integerValueFromPermission)
+                     .max()
+                     .orElse(defaultValue);
+    }
+}


### PR DESCRIPTION
Also increments version and adds a helper class to encapsulate some of the functionality of `checkMaxShulker`, reduces code reuse a bit.